### PR TITLE
Fix terminal size and insert problem

### DIFF
--- a/plugin/nvim-go.vim
+++ b/plugin/nvim-go.vim
@@ -66,11 +66,11 @@ let g:go#lint#metalinter#skip_dir       = get(g:, 'go#lint#metalinter#skip_dir',
 let g:go#rename#prefill = get(g:, 'go#rename#prefill', 0)
 
 " Terminal
-let g:go#terminal#mode         = get(g:, 'go#terminal#mode', 'vsplit')
-let g:go#terminal#position     = get(g:, 'go#terminal#position', 'belowright')
-let g:go#terminal#height       = get(g:, 'go#terminal#height', 0)
-let g:go#terminal#width        = get(g:, 'go#terminal#width', 0)
-let g:go#terminal#start_insert = get(g:, 'go#terminal#start_insert', 0)
+let g:go#terminal#mode        = get(g:, 'go#terminal#mode', 'vsplit')
+let g:go#terminal#position    = get(g:, 'go#terminal#position', 'belowright')
+let g:go#terminal#height      = get(g:, 'go#terminal#height', 0)
+let g:go#terminal#width       = get(g:, 'go#terminal#width', 0)
+let g:go#terminal#stop_insert = get(g:, 'go#terminal#stop_insert', 0)
 
 " GoTest
 let g:go#test#autosave = get(g:, 'go#test#autosave', 0)
@@ -111,7 +111,7 @@ call remote#host#Register(s:plugin_name, '*', function('s:RequireNvimGo'))
 call remote#host#RegisterPlugin('nvim-go', '0', [
 \ {'type': 'autocmd', 'name': 'BufWritePost', 'sync': 0, 'opts': {'eval': '[getcwd(), expand(''%:p:h'')]', 'group': 'nvim-go', 'pattern': '*.go'}},
 \ {'type': 'autocmd', 'name': 'BufWritePre', 'sync': 0, 'opts': {'eval': '[getcwd(), expand(''%:p'')]', 'group': 'nvim-go', 'pattern': '*.go'}},
-\ {'type': 'autocmd', 'name': 'VimEnter', 'sync': 0, 'opts': {'eval': '{''Global'': {''ServerName'': v:servername, ''ErrorListType'': g:go#global#errorlisttype}, ''Analyze'': {''FoldIcon'': g:go#analyze#foldicon}, ''Build'': {''Autosave'': g:go#build#autosave, ''Force'': g:go#build#force, ''Flags'': g:go#build#flags}, ''Fmt'': {''Autosave'': g:go#fmt#autosave, ''Mode'': g:go#fmt#mode}, ''Generate'': {''TestExclFuncs'': g:go#generate#test#exclude}, ''Guru'': {''Reflection'': g:go#guru#reflection, ''KeepCursor'': g:go#guru#keep_cursor, ''JumpFirst'': g:go#guru#jump_first}, ''Iferr'': {''Autosave'': g:go#iferr#autosave}, ''Lint'': {''GolintIgnore'': g:go#lint#golint#ignore, ''GolintMinConfidence'': g:go#lint#golint#min_confidence, ''GolintMode'': g:go#lint#golint#mode, ''GoVetAutosave'': g:go#lint#govet#autosave, ''GoVetFlags'': g:go#lint#govet#flags, ''MetalinterAutosave'': g:go#lint#metalinter#autosave, ''MetalinterAutosaveTools'': g:go#lint#metalinter#autosave#tools, ''MetalinterTools'': g:go#lint#metalinter#tools, ''MetalinterDeadline'': g:go#lint#metalinter#deadline, ''MetalinterSkipDir'': g:go#lint#metalinter#skip_dir}, ''Rename'': {''Prefill'': g:go#rename#prefill}, ''Terminal'': {''Mode'': g:go#terminal#mode, ''Position'': g:go#terminal#position, ''Height'': g:go#terminal#height, ''Width'': g:go#terminal#width, ''StartInsetrt'': g:go#terminal#start_insert}, ''Test'': {''Autosave'': g:go#test#autosave, ''Flags'': g:go#test#flags}, ''Debug'': {''Enable'': g:go#debug, ''Pprof'': g:go#debug#pprof}}', 'group': 'nvim-go', 'pattern': '*.go'}},
+\ {'type': 'autocmd', 'name': 'VimEnter', 'sync': 0, 'opts': {'eval': '{''Global'': {''ServerName'': v:servername, ''ErrorListType'': g:go#global#errorlisttype}, ''Analyze'': {''FoldIcon'': g:go#analyze#foldicon}, ''Build'': {''Autosave'': g:go#build#autosave, ''Force'': g:go#build#force, ''Flags'': g:go#build#flags}, ''Fmt'': {''Autosave'': g:go#fmt#autosave, ''Mode'': g:go#fmt#mode}, ''Generate'': {''TestExclFuncs'': g:go#generate#test#exclude}, ''Guru'': {''Reflection'': g:go#guru#reflection, ''KeepCursor'': g:go#guru#keep_cursor, ''JumpFirst'': g:go#guru#jump_first}, ''Iferr'': {''Autosave'': g:go#iferr#autosave}, ''Lint'': {''GolintIgnore'': g:go#lint#golint#ignore, ''GolintMinConfidence'': g:go#lint#golint#min_confidence, ''GolintMode'': g:go#lint#golint#mode, ''GoVetAutosave'': g:go#lint#govet#autosave, ''GoVetFlags'': g:go#lint#govet#flags, ''MetalinterAutosave'': g:go#lint#metalinter#autosave, ''MetalinterAutosaveTools'': g:go#lint#metalinter#autosave#tools, ''MetalinterTools'': g:go#lint#metalinter#tools, ''MetalinterDeadline'': g:go#lint#metalinter#deadline, ''MetalinterSkipDir'': g:go#lint#metalinter#skip_dir}, ''Rename'': {''Prefill'': g:go#rename#prefill}, ''Terminal'': {''Mode'': g:go#terminal#mode, ''Position'': g:go#terminal#position, ''Height'': g:go#terminal#height, ''Width'': g:go#terminal#width, ''StopInsert'': g:go#terminal#stop_insert}, ''Test'': {''Autosave'': g:go#test#autosave, ''Flags'': g:go#test#flags}, ''Debug'': {''Enable'': g:go#debug, ''Pprof'': g:go#debug#pprof}}', 'group': 'nvim-go', 'pattern': '*.go'}},
 \ {'type': 'autocmd', 'name': 'VimLeavePre', 'sync': 0, 'opts': {'group': 'nvim-go', 'pattern': '*.go,terminal,context,thread'}},
 \ {'type': 'command', 'name': 'DlvBreakpoint', 'sync': 0, 'opts': {'complete': 'customlist,FunctionsCompletion', 'eval': '[expand(''%:p'')]', 'nargs': '*'}},
 \ {'type': 'command', 'name': 'DlvConnect', 'sync': 0, 'opts': {'eval': '[getcwd(), expand(''%:p:h'')]', 'nargs': '*'}},

--- a/plugin/nvim-go.vim
+++ b/plugin/nvim-go.vim
@@ -70,7 +70,7 @@ let g:go#terminal#mode        = get(g:, 'go#terminal#mode', 'vsplit')
 let g:go#terminal#position    = get(g:, 'go#terminal#position', 'belowright')
 let g:go#terminal#height      = get(g:, 'go#terminal#height', 0)
 let g:go#terminal#width       = get(g:, 'go#terminal#width', 0)
-let g:go#terminal#stop_insert = get(g:, 'go#terminal#stop_insert', 0)
+let g:go#terminal#stop_insert = get(g:, 'go#terminal#stop_insert', 1)
 
 " GoTest
 let g:go#test#autosave = get(g:, 'go#test#autosave', 0)

--- a/src/nvim-go/config/config.go
+++ b/src/nvim-go/config/config.go
@@ -89,11 +89,11 @@ type rename struct {
 
 // terminal represents a configure of Neovim terminal buffer.
 type terminal struct {
-	Mode         string `eval:"g:go#terminal#mode"`
-	Position     string `eval:"g:go#terminal#position"`
-	Height       int64  `eval:"g:go#terminal#height"`
-	Width        int64  `eval:"g:go#terminal#width"`
-	StartInsetrt int64  `eval:"g:go#terminal#start_insert"`
+	Mode       string `eval:"g:go#terminal#mode"`
+	Position   string `eval:"g:go#terminal#position"`
+	Height     int64  `eval:"g:go#terminal#height"`
+	Width      int64  `eval:"g:go#terminal#width"`
+	StopInsert int64  `eval:"g:go#terminal#stop_insert"`
 }
 
 // Test represents a GoTest command config variables.
@@ -176,8 +176,8 @@ var (
 	TerminalHeight int64
 	// TerminalWidth open the terminal window width.
 	TerminalWidth int64
-	// TerminalStartInsert workaround if users set "autocmd BufEnter term://* startinsert".
-	TerminalStartInsert bool
+	// TerminalStopInsert workaround if users set "autocmd BufEnter term://* startinsert".
+	TerminalStopInsert bool
 
 	// TestAutosave call the GoBuild command automatically at during the BufWritePost.
 	TestAutosave bool
@@ -240,7 +240,7 @@ func Get(v *nvim.Nvim, cfg *Config) {
 	TerminalPosition = cfg.Terminal.Position
 	TerminalHeight = cfg.Terminal.Height
 	TerminalWidth = cfg.Terminal.Width
-	TerminalStartInsert = itob(cfg.Terminal.StartInsetrt)
+	TerminalStopInsert = itob(cfg.Terminal.StopInsert)
 
 	// Test
 	TestAutosave = itob(cfg.Test.Autosave)

--- a/src/nvim-go/nvimutil/buffer.go
+++ b/src/nvim-go/nvimutil/buffer.go
@@ -29,6 +29,8 @@ type Buf struct {
 	Filetype string
 	Bufnr    int
 	Mode     string
+	Height   int
+	Width    int
 	Data     []byte
 
 	WindowContext
@@ -56,6 +58,13 @@ func (b *Buf) Create(name, filetype, mode string, option map[NvimOption]map[stri
 
 	if err := b.GetBufferContext(); err != nil {
 		return errors.Wrap(err, pkgBuffer)
+	}
+
+	if b.Height != 0 {
+		b.p.SetWindowHeight(b.Window, b.Height)
+	}
+	if b.Width != 0 {
+		b.p.SetWindowWidth(b.Window, b.Width)
 	}
 
 	b.p.BufferNumber(b.Buffer, &b.Bufnr)

--- a/src/nvim-go/nvimutil/terminal.go
+++ b/src/nvim-go/nvimutil/terminal.go
@@ -57,9 +57,9 @@ func (t *Terminal) Create() (err error) {
 
 	switch {
 	case t.mode == "split":
-		t.Size = int(config.TerminalHeight)
+		t.Size = t.getWindowSize(config.TerminalHeight, t.v.WindowHeight)
 	case t.mode == "vsplit":
-		t.Size = int(config.TerminalWidth)
+		t.Size = t.getWindowSize(config.TerminalWidth, t.v.WindowWidth)
 	default:
 		// nothing to do
 	}
@@ -113,6 +113,18 @@ func (t *Terminal) Run(cmd []string) error {
 	}
 
 	return nil
+}
+
+// getWindowSize return the one third of window (height|width) size if cfg is 0
+func (t *Terminal) getWindowSize(cfg int64, fn func(nvim.Window) (int, error)) int {
+	if cfg == 0 {
+		i, err := fn(t.cw)
+		if err != nil {
+			return 0
+		}
+		return i / 3
+	}
+	return int(cfg)
 }
 
 // TODO(zchee): flashing when switch the window.

--- a/src/nvim-go/nvimutil/terminal.go
+++ b/src/nvim-go/nvimutil/terminal.go
@@ -55,11 +55,15 @@ func (t *Terminal) Create() (err error) {
 		return err
 	}
 
+	t.Buf = NewBuffer(t.v)
+
 	switch {
 	case t.mode == "split":
 		t.Size = t.getWindowSize(config.TerminalHeight, t.v.WindowHeight)
+		t.Buf.Height = t.Size
 	case t.mode == "vsplit":
 		t.Size = t.getWindowSize(config.TerminalWidth, t.v.WindowWidth)
+		t.Buf.Width = t.Size
 	default:
 		// nothing to do
 	}
@@ -67,17 +71,11 @@ func (t *Terminal) Create() (err error) {
 	option := t.setTerminalOption()
 	name := fmt.Sprintf("| terminal %s", strings.Join(t.cmd, " "))
 	mode := fmt.Sprintf("%s %d%s", config.TerminalPosition, t.Size, t.mode)
-	t.Buf = NewBuffer(t.v)
+
 	t.Buf.Create(name, FiletypeTerminal, mode, option)
 	t.Buf.Name = t.Name
 	t.Buf.UpdateSyntax(FiletypeTerminal)
 
-	// Get terminal buffer and windows information.
-	t.p.CurrentBuffer(&t.Buffer)
-	t.p.CurrentWindow(&t.Window)
-	if err := t.p.Wait(); err != nil {
-		return err
-	}
 	defer t.switchFocus()()
 
 	// Cleanup cursor highlighting

--- a/src/nvim-go/nvimutil/terminal.go
+++ b/src/nvim-go/nvimutil/terminal.go
@@ -108,7 +108,7 @@ func (t *Terminal) Run(cmd []string) error {
 		t.Create()
 	}
 	// Workaround for "autocmd BufEnter term://* startinsert"
-	if config.TerminalStartInsert {
+	if config.TerminalStopInsert {
 		t.v.Command("stopinsert")
 	}
 


### PR DESCRIPTION
Fix the terminal (height|width) size will `0` if not set `go#terminal#{height,width}`.
For now, one-third of current(editing) buffer size by default.

Also change `g:go#terminal#stop_insert` default variable to `1` because nvim users might be set the `autocmd BufEnter term://* startinsert`.