### PR TITLE
Fix plugin failing to build due to nonexistent revision in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/motemen/go-astmanip v0.0.0-20160104081417-d6ad31f02153
-	github.com/neovim/go-client v0.0.0-20181201035206-cb423a764808
+	github.com/neovim/go-client v0.0.0-20190307061348-177c72b37553
 	github.com/peterh/liner v1.1.0 // indirect
 	github.com/pkg/errors v0.0.0-20181023235946-059132a15dd0
 	github.com/pkg/profile v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJE
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/neovim/go-client v0.0.0-20181201035206-cb423a764808 h1:iNv2fPhonX9Np2HGka4lHyxpY0Sncg9/s4xlOD4xg8M=
 github.com/neovim/go-client v0.0.0-20181201035206-cb423a764808/go.mod h1:cHx8fl6EhCgSA/pyKeVtyl3o6UzgE31ADtc+bx3JpKg=
+github.com/neovim/go-client v0.0.0-20190307061348-177c72b37553 h1:yw9nEF0ce6tsoo9V9m6k49aWt2yW1v++9aB8lF9HuXc=
+github.com/neovim/go-client v0.0.0-20190307061348-177c72b37553/go.mod h1:cHx8fl6EhCgSA/pyKeVtyl3o6UzgE31ADtc+bx3JpKg=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/peterh/liner v1.1.0 h1:f+aAedNJA6uk7+6rXsYBnhdo4Xux7ESLe+kcuVUF5os=
 github.com/peterh/liner v1.1.0/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=


### PR DESCRIPTION
The plugin currently fails to build when installed through `Plug 'zchee/nvim-go', { 'do': 'make' }` due to a missing revision in one of its dependencies:

```sh
Thu Mar 14 13:53:09 EDT 2019 → make
go: finding github.com/neovim/go-client v0.0.0-20181201035206-cb423a764808
go: finding github.com/go-ini/ini v1.25.4
go: finding github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e
go: finding github.com/gogo/protobuf v1.1.1
go: finding golang.org/x/net v0.0.0-20180826012351-8a410e7b638d
go: finding golang.org/x/lint v0.0.0-20180702182130-06c8688daad7
go: finding golang.org/x/sys v0.0.0-20180830151530-49385e6e1522
go: finding google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
go: finding honnef.co/go/tools v0.0.0-20180728063816-88497007e858
go: finding sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4
go: finding github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041
go: github.com/neovim/go-client@v0.0.0-20181201035206-cb423a764808: unknown revision cb423a764808
go: error loading module requirements
go: finding github.com/neovim/go-client v0.0.0-20181201035206-cb423a764808
go: github.com/neovim/go-client@v0.0.0-20181201035206-cb423a764808: unknown revision cb423a764808
go: error loading module requirements
fatal: No tags can describe '1fbb3699e9d67edf6d5b48a4cfa2a3993f22da4d'.
Try --always, or create some tags.
+ build
go build -v -o ./bin/nvim-go -tags "osusergo netgo" -installsuffix netgo  -ldflags="-X=main.tag= -X=main.gitCommit=1fbb369" ./cmd/nvim-go
go: finding github.com/neovim/go-client v0.0.0-20181201035206-cb423a764808
go: github.com/neovim/go-client@v0.0.0-20181201035206-cb423a764808: unknown revision cb423a764808
go: error loading module requirements
make: *** [Makefile:84: build] Error 1
```